### PR TITLE
Add a clickable link on the page's title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
   <body>
     <header>
       <div class="inner">
-        <h1><a href="{{ site.baseurl }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+        <a href="{{ '/' | absolute_url }}"><h1>{{ site.title | default: site.github.repository_name }}</h1></a>
         <h2>{{ site.description | default: site.github.project_tagline }}</h2>
         {% if site.github.is_project_page %}
           <a href="{{ site.github.repository_url }}" class="button"><small>View project on</small> GitHub</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
   <body>
     <header>
       <div class="inner">
-        <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        <h1><a href="{{ site.baseurl }}">{{ site.title | default: site.github.repository_name }}</a></h1>
         <h2>{{ site.description | default: site.github.project_tagline }}</h2>
         {% if site.github.is_project_page %}
           <a href="{{ site.github.repository_url }}" class="button"><small>View project on</small> GitHub</a>


### PR DESCRIPTION
Adding a clickable link is great for SEO.

Just kidding, I think that not all GitHub Pages websites are
single page, and being able to go back to the front page is
a precious thing. Without this patch, repositories that want
to achieve this have to fork the whole layout, which is bad.

Again, if you know/have better ways to do this, feel free