### PR TITLE
Update jekyll-theme-architect.scss to remove bad image reference in footer styling

### DIFF
--- a/_sass/jekyll-theme-architect.scss
+++ b/_sass/jekyll-theme-architect.scss
@@ -322,7 +322,6 @@ footer {
   margin-top: 40px;
   font-size: 13px;
   color: #aaa;
-  background: transparent url('../images/hr.png') 0 0 no-repeat;
 }
 
 footer a {


### PR DESCRIPTION
Fix Issue #10 by removing bad image reference