### PR TITLE
changed header h1 font-size from 72px to 4vw

### DIFF
--- a/_sass/jekyll-theme-architect.scss
+++ b/_sass/jekyll-theme-architect.scss
@@ -35,7 +35,7 @@ header h1 {
   width: 540px;
   margin-top: 0;
   margin-bottom: 0.2em;
-  font-size: 72px;
+  font-size: 4vw;
   font-weight: normal;
   line-height: 1;
   color: #fff;

--- a/_sass/jekyll-theme-architect.scss
+++ b/_sass/jekyll-theme-architect.scss
@@ -360,7 +360,7 @@ footer a:hover {
     width: 340px;
   }
   header h1 {
-    font-size: 60px;
+    font-size: 8vw;
   }
   header h2 {
     font-size: 30px;
@@ -395,7 +395,7 @@ footer a:hover {
     width: 100%;
   }
   header h1 {
-    font-size: 48px;
+    font-size: 8vw;
   }
   header h2 {
     font-size: 24px;


### PR DESCRIPTION
# I have changed the header h1 font-size from 72px to 4vw which is because the text is going outside the bg-image on the phone as my domain is a bit long. So I changed the unit to viewport width which makes the text responsive and it looks the same on all devices. I have attached the screenshot of how it is looking with font-size set to 72px. Notice that the ".io" part of the header is going outside.
![old](https://user-images.githubusercontent.com/68607350/89118172-14be1680-d4c1-11ea-8980-b2bde2d1a991.jpeg)