### PR TITLE
Added conditional download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Additionally, you may choose to set the following optional variables:
 
 ```yml
 show_downloads: ["true" or "false" to indicate whether to provide a download URL]
+    zip_url: ["true" or "false" to indicate whether to provide a .zip download URL]
+    tar_url: ["true" or "false" to indicate whether to provide a .tar.gz download URL]
 google_analytics: [Your Google Analytics tracking ID]
 ```
 
@@ -74,7 +76,7 @@ Templates often rely on URLs supplied by GitHub such as links to your repository
     ```yml
     github:
       zip_url: http://example.com/download.zip
-      another_url: another value
+      tar_url: http://example.com/download.tar.gz
     ```
 3. When your site is built, Jekyll will use the URL you specified, rather than the default one provided by GitHub.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,7 @@
 title: Architect theme
 description: Architect is a theme for GitHub Pages.
 show_downloads: true
+  zip_url: true
+  tar_url: true
 google_analytics:
 theme: jekyll-theme-architect

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,14 +38,18 @@
 
         <aside id="sidebar">
           {% if site.show_downloads %}
+            {% if site.show_downloads.zip_url %}
             <a href="{{ site.github.zip_url }}" class="button">
               <small>Download</small>
               .zip file
             </a>
+            {% endif %}
+            {% if site.show_downloads.tar_url %}
             <a href="{{ site.github.tar_url }}" class="button">
               <small>Download</small>
               .tar.gz file
             </a>
+            {% endif %}
           {% endif %}
 
           {% if site.github.is_project_page %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,13 +38,13 @@
 
         <aside id="sidebar">
           {% if site.show_downloads %}
-            {% if site.show_downloads.zip_url %}
+            {% if site.show_downloads.zip_url|default(true) %}
             <a href="{{ site.github.zip_url }}" class="button">
               <small>Download</small>
               .zip file
             </a>
             {% endif %}
-            {% if site.show_downloads.tar_url %}
+            {% if site.show_downloads.tar_url|default(true) %}
             <a href="{{ site.github.tar_url }}" class="button">
               <small>Download</small>
               .tar.gz file


### PR DESCRIPTION
## Enhancements
- Links can be enabled/disabled conditionally
- If config values for the links are not defined it defaults to `true` (also works as a safeguard for existing installations that have only `show_downloads` defined to prevent them from breaking)