### PR TITLE
remove text-indent for headings in mobile

### DIFF
--- a/_sass/jekyll-theme-architect.scss
+++ b/_sass/jekyll-theme-architect.scss
@@ -446,6 +446,14 @@ footer a:hover {
     margin-left: 0;
     content: none;
   }
+  #main-content h1,
+  #main-content h2,
+  #main-content h3,
+  #main-content h4,
+  #main-content h5,
+  #main-content h6 {
+    text-indent: 0;
+  }
 }
 
 /* Mobile Landscape Size to Tablet Portrait (devices and browsers) */


### PR DESCRIPTION
## Problem
`text-indent` was introduced for compensating the blue ticks before the headings 
https://github.com/pages-themes/architect/blob/27f3b20dfb55063555c3f029dcffe75f3d067fb2/_sass/jekyll-theme-architect.scss#L197

They were not removed in mobile, whereas the blue ticks were removed 
https://github.com/pages-themes/architect/blob/27f3b20dfb55063555c3f029dcffe75f3d067fb2/_sass/jekyll-theme-architect.scss#L377-L379

This results in extra indentation in mobile.

## Solution
This css change removes unnecessary `text-indent` in mobile.

## Before / After
Using my own page because I am a bit lazy for reproducing this...
| before | after |
| --- | --- |
| ![Screenshot_20211219-144322_Chrome - Copy (2)](https://user-images.githubusercontent.com/1209810/146666623-a957e184-ebc7-41da-8f66-63b18adeef6b.jpg) | ![Screenshot_20211219-144355_Chrome (2)](https://user-images.githubusercontent.com/1209810/146666615-4c270dab-f8cc-4023-aad7-93c9afa3ce60.jpg) |

live website effect reference: https://retire35.com/
